### PR TITLE
Rename to RALF, cleanup, and signature specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,24 @@
-# OCI Package Specification
+# RALF (RDK Application Layer Format) Specification
 
-This repository contains the OCI Package Specification, which defines a standard for packaging applications, runtimes, and other resources as OCI (Open Container Initiative) artifacts. This specification is designed to provide a clear and consistent way to bundle and distribute software components.
+This repository contains the **RALF (RDK Application Layer Format) Specification**, which defines a standard for packaging applications, runtimes, and other resources as OCI (Open Container Initiative) artifacts for RDK devices.
+
+RALF packages are distributed as single files with the `.ralf` extension (ZIP or Tarball) containing a standard OCI Image Layout.
 
 ## Specification Documents
 
-*   **[Package Format Specification (format.md)](format.md):** This document describes the structure of an OCI package, including the different layers and their corresponding media types. It details how to bundle package payloads and metadata into a single OCI artifact.
+*   **[RALF Format Specification (format.md)](format.md):** This document describes the structure of a RALF package (`.ralf`), including the file format (ZIP/Tar), internal OCI layout, layers, media types, and the **Cosign-based signing** mechanism.
 
-*   **[Package Metadata Specification (metadata.md)](metadata.md):** This document defines the metadata that can be included in a package. This metadata provides essential information about the package, such as its name, version, dependencies, and required permissions.
+*   **[Package Metadata Specification (metadata.md)](metadata.md):** This document defines the metadata that can be included in a package's config layer. This metadata provides essential information such as package name, version, dependencies, permissions, and resource requirements.
 
 *   **[Package Metadata JSON Schema (package.schema.json)](schema/package.schema.json):** This file provides a JSON schema for validating the package metadata.
 
+## Key Features
+
+*   **OCI Standard**: Built on open standards (OCI Image Spec, OCI Image Layout).
+*   **Single File Distribution**: Packages are bundled as `.ralf` files (ZIP or Tarball).
+*   **Secure**: Supports offline verification using Cosign-style signatures.
+*   **Flexible**: Supports various payloads including Tarballs and EROFS images with dm-verity.
+
 ## Contributing
 
-Contributions to the OCI Package Specification are welcome. If you have any suggestions or improvements, please feel free to open an issue or submit a pull request.
+Contributions to the RALF Specification are welcome. If you have any suggestions or improvements, please feel free to open an issue or submit a pull request.

--- a/format.md
+++ b/format.md
@@ -277,6 +277,7 @@ Browser example runtime package.
 ## Signing
 
 Packages MAY be signed using the Cosign "simple signing" format. This allows for offline verification of packages without reliance on an OCI registry.
+The signature follows [Cosign Signature Specification](https://github.com/sigstore/cosign/blob/main/specs/SIGNATURE_SPEC.md).
 
 ### Signature Artifact
 
@@ -297,13 +298,15 @@ The Signature Manifest consists of a single layer containing the signed payload.
 The signature layer MUST use the media type:
 `application/vnd.dev.cosign.simplesigning.v1+json`
 
-The layer descriptor MUST contain the following annotations:
+The layer descriptor contains the following annotations:
 
-| Annotation Key                     | Description                                            |
-| ---------------------------------- | ------------------------------------------------------ |
-| `dev.cosignproject.cosign/signature` | The base64-encoded signature of the layer's content (payload). |
-| `dev.sigstore.cosign/certificate`    | The PEM-encoded X.509 certificate used for signing.    |
-| `dev.sigstore.cosign/chain`          | (Optional) The PEM-encoded certificate chain.          |
+| Annotation Key                       | Requirement | Description                                                    |
+| ------------------------------------ | ----------- | -------------------------------------------------------------- |
+| `dev.cosignproject.cosign/signature` | Required    | The base64-encoded signature of the layer's content (payload). |
+| `dev.sigstore.cosign/certificate`    | Optional    | The PEM-encoded X.509 certificate used for signing.            |
+| `dev.sigstore.cosign/chain`          | Optional    | The PEM-encoded certificate chain.                             |
+
+`dev.sigstore.cosign/certificate` and `dev.sigstore.cosign/chain` are not required. It is possible to just sign with public / private key, rather than PKI certificate chains.
 
 #### Signature Payload
 
@@ -323,6 +326,10 @@ The content of the signature layer (the blob) is a JSON object with the followin
   "optional": null
 }
 ```
+
+`docker-reference` is a string that identifies the signed artifact. It does not
+have to follow any specific format, but it is recommended to use a format that clearly indicates the artifact being
+signed (e.g., `com.sky.rdkbrowser:2.7.2-kirkstone`).
 
 ### Key Generation (Informative)
 
@@ -414,7 +421,7 @@ The index links the target package and its signature.
 {
   "critical": {
     "identity": {
-      "docker-reference": "10.211.55.6:5001/tcpconnect"
+      "docker-reference": "com.sky.rdkbrowser:2.7.2-kirkstone"
     },
     "image": {
       "docker-manifest-digest": "sha256:4161227e2a40097d5e00150b6027e86ea78a03f3668d41cf240173dc9b199614"

--- a/format.md
+++ b/format.md
@@ -57,7 +57,7 @@ The following manifest provide an example of the OCI Artifact descriptors for an
   "config": {
     "mediaType": "application/vnd.rdk.package.config.v1+json",
     "digest": "sha256:<digest>",
-    "size": "<size>",
+    "size": <size>,
     "annotations": {
       "org.opencontainers.image.title": "package.json"
     }
@@ -66,7 +66,7 @@ The following manifest provide an example of the OCI Artifact descriptors for an
     {
       "mediaType": "application/vnd.rdk.package.content.layer.v1.tar+gzip",
       "digest": "sha256:<digest>",
-      "size": "<size>",
+      "size": <size>,
       "annotations": {
         "org.opencontainers.image.title": "package.tar.gz"
       }
@@ -144,7 +144,7 @@ The following manifest provides an example of the OCI Artifact descriptors for a
   "config": {
     "mediaType": "application/vnd.rdk.package.config.v1+json",
     "digest": "sha256:<digest>",
-    "size": "<size>",
+    "size": <size>,
     "annotations": {
       "org.opencontainers.image.title": "package.json"
     }
@@ -209,7 +209,7 @@ The following manifest provide an example of the OCI Artifact descriptors for an
   "config": {
     "mediaType": "application/vnd.rdk.package.config.v1+json",
     "digest": "sha256:<digest>",
-    "size": "<size>",
+    "size": <size>,
     "annotations": {
       "org.opencontainers.image.title": "package.json"
     }
@@ -218,7 +218,7 @@ The following manifest provide an example of the OCI Artifact descriptors for an
     {
       "mediaType": "application/vnd.rdk.package.content.layer.v1.tar+gzip",
       "digest": "sha256:<digest>",
-      "size": "<size>",
+      "size": <size>,
       "annotations": {
         "org.opencontainers.image.title": "runtime.tar.gz"
       }
@@ -272,4 +272,155 @@ Browser example runtime package.
 │ ├── ...
 │ └── libWpeQueryExtension.so
 └── libSkyWebKitBackend.so
+```
+
+## Signing
+
+Packages MAY be signed using the Cosign "simple signing" format. This allows for offline verification of packages without reliance on an OCI registry.
+
+### Signature Artifact
+
+A signed package consists of two OCI manifests:
+
+1. The **Target Manifest**: The actual package manifest (application or runtime).
+2. The **Signature Manifest**: A separate manifest containing the signature data.
+
+The Signature Manifest MUST be associated with the Target Manifest via the `org.opencontainers.image.ref.name` annotation. The value of this annotation MUST follow the pattern:
+`sha256-<target_manifest_digest>.sig`
+
+### Signature Structure
+
+The Signature Manifest consists of a single layer containing the signed payload.
+
+#### Signature Layer
+
+The signature layer MUST use the media type:
+`application/vnd.dev.cosign.simplesigning.v1+json`
+
+The layer descriptor MUST contain the following annotations:
+
+| Annotation Key                     | Description                                            |
+| ---------------------------------- | ------------------------------------------------------ |
+| `dev.cosignproject.cosign/signature` | The base64-encoded signature of the layer's content (payload). |
+| `dev.sigstore.cosign/certificate`    | The PEM-encoded X.509 certificate used for signing.    |
+| `dev.sigstore.cosign/chain`          | (Optional) The PEM-encoded certificate chain.          |
+
+#### Signature Payload
+
+The content of the signature layer (the blob) is a JSON object with the following structure:
+
+```json
+{
+  "critical": {
+    "identity": {
+      "docker-reference": "<reference>"
+    },
+    "image": {
+      "docker-manifest-digest": "<sha256_digest_of_target_manifest>"
+    },
+    "type": "cosign container image signature"
+  },
+  "optional": null
+}
+```
+
+### Key Generation (Informative)
+
+The following commands demonstrate how to generate a self-signed certificate and key pair using OpenSSL for testing purposes.
+
+**1. Generate Root Private Key**
+
+```bash
+openssl genrsa -out rootCA.key 4096
+```
+
+**2. Create Self-Signed Certificate**
+
+```bash
+openssl req -x509 -new -nodes -key rootCA.key -sha512 -days 3650 -out rootCA.pem
+```
+
+**3. Generate PKCS#12 Certificate**
+
+```bash
+openssl pkcs12 -export -in ./rootCA.pem -inkey ./rootCA.key -out <path_to_new_pkcs12>
+```
+
+### Example: Signed Package
+
+#### Index (index.json)
+
+The index links the target package and its signature.
+
+```json
+{
+  "schemaVersion": 2,
+  "manifests": [
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:4161227e2a40097d5e00150b6027e86ea78a03f3668d41cf240173dc9b199614",
+      "size": 469,
+      "annotations": {
+        "org.opencontainers.image.ref.name": "test"
+      }
+    },
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:f85bf2af0b25c1e0774ecc283e192fddc4dafbb33ef5ec47a863c1f1880fc48f",
+      "size": 9299,
+      "annotations": {
+        "org.opencontainers.image.ref.name": "sha256-4161227e2a40097d5e00150b6027e86ea78a03f3668d41cf240173dc9b199614.sig"
+      }
+    }
+  ]
+}
+```
+
+#### Signature Manifest
+
+(Digest: `sha256:f85bf2af0b25c1e0774ecc283e192fddc4dafbb33ef5ec47a863c1f1880fc48f`)
+
+```json
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "config": {
+    "mediaType": "application/vnd.oci.image.config.v1+json",
+    "size": 342,
+    "digest": "sha256:5ba08d0c9572e6bcec408cec3116751b3724e8d7c3c5d5d7d74453085d6ef223"
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.dev.cosign.simplesigning.v1+json",
+      "size": 243,
+      "digest": "sha256:f55379abf8de5f1abedab0cd5399c1a1c7a3d60636fe654e3f03779f8ed42fc4",
+      "annotations": {
+        "dev.cosignproject.cosign/signature": "R/E7xo8xv1O3uVQVqXNXDp8AXqynRe5ksIywmeWoIr47AMgQWq9uoSMWDaBF+D3KPulAhYpk4LTmTWnwO3b9Xx3IeZA0ZRUHWjfZZy+4DMMUFDgxRT6sl7j7KNvcfQkGSqL7W71ulsjESFDFRKgaNP8VQfCbf6LiZLOPiA4Q+HD3qVlx4uNPVfGbziMC0m+T28EeY8Z2vyggc/9ZC5SbA944S0PRD5CDasXVNFDXEo6KjSjd4czIRjcsw6OLakd7hOiVeIAdYxqq0bc8I35RN/Q4qwB7gIrj5eQQAH8OdgEDNNGBgmhgonVqil4+jhTr/b+9vfPmljl2sk2eBF8PD2E0jravPbY8+bbr8OwEMwSbl0uPGu/+ZU14xRpzbUHz8L9+rge+v9yoLejXlwcL8BdFBevFAoIaQCVf0w2E+AqeMRm9wnk8o+yOGyyCyRW1IT0LhewkEyL5TklEHQJx/j67Y8Ga5ghb5ZEEWnQltCrwBm9QD3w3k+u9mscpEeyO5JrhkSvJptZw6fLtsxh9YNJdRRsdrN+PxfUxWfNr9R7AuPlb+QyUg8Nzk/ABDFTp/DiV3BmvCS1V55/ucOBWJOIghT55QEnk7dlwn+rl92amtnBQ+KFRmoJjAmBESozfu5T8H0Ehj/Z46fMBoRwcPyxkm0rfTR/r/lHRU3uku0Y=",
+        "dev.sigstore.cosign/certificate": "-----BEGIN CERTIFICATE-----\nMIIFhjCCA26gAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwQTELMAkGA1UEBhMCR0Ix\n...\n-----END CERTIFICATE-----
+",
+        "dev.sigstore.cosign/chain": "-----BEGIN CERTIFICATE-----\nMIIFRjCCAy6gAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwOTELMAkGA1UEBhMCR0Ix\n...\n-----END CERTIFICATE-----
+"
+      }
+    }
+  ]
+}
+```
+
+#### Signature Layer Payload
+
+(Digest: `sha256:f55379abf8de5f1abedab0cd5399c1a1c7a3d60636fe654e3f03779f8ed42fc4`)
+
+```json
+{
+  "critical": {
+    "identity": {
+      "docker-reference": "10.211.55.6:5001/tcpconnect"
+    },
+    "image": {
+      "docker-manifest-digest": "sha256:4161227e2a40097d5e00150b6027e86ea78a03f3668d41cf240173dc9b199614"
+    },
+    "type": "cosign container image signature"
+  },
+  "optional": null
+}
 ```


### PR DESCRIPTION
This pull request introduces significant updates to the specification, focusing on re-branding and adding security features:

**1. Project Rename to RALF:**

- Updated README.md to officially rename the project from "OCI Package Specification" to RALF (RDK Application Layer Format).
- Clarified the file extension (.ralf) and core components in the documentation.

**2. New Signing Specification:**

- Added a major section to format.md defining the Cosign "simple signing" mechanism.
- This specification enables offline package verification without requiring an OCI registry.
- Details include:
  - The structure of Signature Artifacts, consisting of a Target Manifest and a linked Signature Manifest.
  - The naming convention for signature references (`sha256-<digest>.sig`).
  - The specific media type for signature layers: `application/vnd.dev.cosign.simplesigning.v1+json`.
  - Required annotations for storing the signature, certificate, and chain.
  - A detailed JSON example of a signed package (Index, Signature Manifest, and Payload).

**3. Format Cleanup:**
- Corrected JSON examples in format.md by removing incorrect quotes around integer size values, ensuring valid JSON types.
