### PR TITLE
Spec versioning and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,93 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+      - 'v*.*.*-*'
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.pages.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from tag
+        id: ver
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify version consistency across files
+        run: |
+          set -euo pipefail
+          V="${{ steps.ver.outputs.version }}"
+          fail() { echo "::error::$1"; exit 1; }
+          grep -Fq "## [$V]" CHANGELOG.md    || fail "CHANGELOG.md missing entry [$V]"
+          grep -Fq "Version: $V" README.md   || fail "README.md version header mismatch (expected $V)"
+          grep -Fq "Version: $V" format.md   || fail "format.md version header mismatch (expected $V)"
+          grep -Fq "Version: $V" metadata.md || fail "metadata.md version header mismatch (expected $V)"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Validate schema compiles
+        run: npx --yes ajv-cli@5 compile -s schema/v1/package.schema.json --spec=draft2020
+
+      - name: Extract changelog section for this release
+        run: |
+          V="${{ steps.ver.outputs.version }}"
+          awk -v v="$V" '
+            $0 ~ "^## \\["v"\\]" { flag=1; next }
+            flag && /^## \[/ { exit }
+            flag { print }
+          ' CHANGELOG.md > RELEASE_NOTES.md
+          test -s RELEASE_NOTES.md || { echo "::error::Empty release notes for $V"; exit 1; }
+
+      - name: Package release artifacts
+        run: |
+          V="${{ steps.ver.outputs.version }}"
+          mkdir -p dist
+          cp schema/v1/package.schema.json "dist/package.schema-v${V}.json"
+          tar czf "dist/ralf-spec-${V}.tar.gz" \
+            README.md format.md metadata.md CHANGELOG.md schema/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: RALF ${{ steps.ver.outputs.version }}
+          body_path: RELEASE_NOTES.md
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          files: |
+            dist/package.schema-*.json
+            dist/ralf-spec-*.tar.gz
+
+      - name: Stage GitHub Pages site
+        run: |
+          mkdir -p site/schema
+          cp -r schema/v1 site/schema/v1
+          cp -r schema/v1 site/schema/latest
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: pages
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,26 @@
+name: Validate
+
+on:
+  pull_request:
+    paths:
+      - 'schema/**'
+      - '*.md'
+      - '.github/workflows/**'
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  schema:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Compile schema with ajv
+        run: npx --yes ajv-cli@5 compile -s schema/v1/package.schema.json --spec=draft2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,16 @@ All notable changes to the RALF Specification will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - 2026-03-16
+## [1.0.0] - 2026-05-11
 
 ### Added
 - Initial formal release of the RALF Specification.
-- Added `specVersion` field to `package.schema.json` and `metadata.md`.
-- Added version headers to documentation files.
-- Established versioning policy for the specification and schema.
+- `specVersion` metadata field (required) declaring the spec version a package was authored against.
+- Versioning policy section in `format.md` covering MAJOR/MINOR/PATCH semantics and schema compatibility.
+- Version headers in `README.md`, `format.md`, and `metadata.md`.
+- MAJOR-versioned schema paths: schema relocated to `schema/v1/package.schema.json` with `$id`
+  pointing at the GitHub Pages canonical URL.
+- Tag-driven release workflow (`.github/workflows/release.yml`) publishing a GitHub Release and the
+  schema on GitHub Pages.
+- PR validation workflow (`.github/workflows/validate.yml`) compiling the schema with ajv.
+- Maintainer release runbook (`RELEASING.md`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to the RALF Specification will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-03-16
+
+### Added
+- Initial formal release of the RALF Specification.
+- Added `specVersion` field to `package.schema.json` and `metadata.md`.
+- Added version headers to documentation files.
+- Established versioning policy for the specification and schema.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # RALF (RDK Application Layer Format) Specification
+**Version: 1.0.0**
 
 This repository contains the **RALF (RDK Application Layer Format) Specification**, which defines a standard for packaging applications, runtimes, and other resources as OCI (Open Container Initiative) artifacts for RDK devices.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ RALF packages are distributed as single files with the `.ralf` extension (ZIP or
 
 *   **[Package Metadata Specification (metadata.md)](metadata.md):** This document defines the metadata that can be included in a package's config layer. This metadata provides essential information such as package name, version, dependencies, permissions, and resource requirements.
 
-*   **[Package Metadata JSON Schema (package.schema.json)](schema/package.schema.json):** This file provides a JSON schema for validating the package metadata.
+*   **[Package Metadata JSON Schema (schema/v1/package.schema.json)](schema/v1/package.schema.json):** JSON Schema for validating the package metadata. Schemas are MAJOR-versioned; the canonical URL for the v1 schema is `https://rdkcentral.github.io/oci-package-spec/schema/v1/package.schema.json`.
+
+*   **[Changelog (CHANGELOG.md)](CHANGELOG.md):** Notable changes per release.
+
+*   **[Release Runbook (RELEASING.md)](RELEASING.md):** How maintainers cut a new spec release.
 
 ## Key Features
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,64 @@
+# Releasing the RALF Specification
+
+This document describes how a maintainer cuts a new release of the RALF Specification. Releases follow
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html); see `format.md` for the policy on what
+constitutes MAJOR/MINOR/PATCH changes.
+
+## Prerequisites
+
+- Push access to `main` and permission to create `v*` tags.
+- The `Validate` workflow is green on `main`.
+- The intended changes are already merged.
+
+## Steps
+
+1. **Decide the version.** Apply the rules in `format.md` to classify the changes as MAJOR, MINOR, or
+   PATCH. For a pre-release, append `-rc.N` (for example `1.1.0-rc.1`).
+
+2. **Open a release PR.** In a single PR:
+   - Update the `**Version: X.Y.Z**` header in `README.md`, `format.md`, and `metadata.md`.
+   - Add a `## [X.Y.Z] - YYYY-MM-DD` section to `CHANGELOG.md` listing the changes (use the
+     Keep a Changelog categories: Added / Changed / Deprecated / Removed / Fixed / Security).
+   - If this is a MAJOR bump, create `schema/vN/package.schema.json` (copy from the previous major,
+     apply the breaking changes, update `$id`) and update references in `format.md`/`metadata.md`.
+
+3. **Merge to `main`** after review and after the Validate workflow passes.
+
+4. **Tag and push.** From a clean checkout of `main`:
+
+   ```bash
+   git fetch --tags
+   git tag -a vX.Y.Z -m "RALF X.Y.Z"
+   git push origin vX.Y.Z
+   ```
+
+5. **Watch the Release workflow.** The workflow runs automatically on the tag push and will:
+   - verify that `CHANGELOG.md` and the doc version headers agree with the tag (`vX.Y.Z` → `X.Y.Z`);
+   - compile the schema with `ajv`;
+   - extract the matching CHANGELOG section as release notes;
+   - publish a GitHub Release with `package.schema-vX.Y.Z.json` and `ralf-spec-X.Y.Z.tar.gz` attached;
+   - deploy the schema to GitHub Pages.
+
+6. **Verify the release.**
+   - Confirm the GitHub Release page lists both artifacts and that pre-release tags are marked as such.
+   - Confirm the canonical schema URL responds with the new content:
+     `https://rdkcentral.github.io/oci-package-spec/schema/v1/package.schema.json`
+   - Optionally validate a sample package against the published schema:
+     ```bash
+     npx ajv-cli@5 validate -s schema/v1/package.schema.json -d sample.json --spec=draft2020
+     ```
+
+## Troubleshooting
+
+- **"CHANGELOG.md missing entry [X.Y.Z]"** — the tag and the CHANGELOG heading disagree. Fix the
+  CHANGELOG on `main` in a follow-up PR, delete the bad tag, then retag.
+- **"version header mismatch"** — one of the doc files still shows the previous version. Same fix
+  as above.
+- **Pages deploy fails on first run** — GitHub Pages must be enabled for the repository with the
+  source set to "GitHub Actions" in Settings → Pages.
+
+## Tag and branch protection (one-time setup)
+
+Configure in the GitHub UI:
+- Tag protection rule `v*` — only maintainers may create matching tags.
+- Branch protection on `main` — require the `Validate` workflow to pass before merge.

--- a/format.md
+++ b/format.md
@@ -1,6 +1,41 @@
 # Package Format Specification
 **Version: 1.0.0**
 
+## Versioning
+
+The RALF Specification follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Each released
+spec version is identified as `MAJOR.MINOR.PATCH` and a package MUST declare the version it was authored
+against via the `specVersion` metadata field (see [metadata.md](metadata.md#specversion)).
+
+| Component | Bump triggers                                                                                                                                |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| MAJOR     | Backwards-incompatible change. A field becomes required, is removed, or is renamed. A media type is removed/renamed. Manifest or signature payload shape changes. |
+| MINOR     | Backwards-compatible additive change. A new optional field, optional media type, or optional annotation is introduced.                       |
+| PATCH     | Editorial change only. Typos, clarifications, example fixes. No normative behaviour change.                                                  |
+
+### Schema Compatibility
+
+The JSON schema is published under MAJOR-versioned paths: `schema/v1/package.schema.json`,
+`schema/v2/package.schema.json`, etc. The schema for a given MAJOR is updated in place across MINOR/PATCH
+releases. A validator implementing MAJOR `N` MUST accept any payload whose declared `specVersion` has
+MAJOR `N`, regardless of its MINOR/PATCH value. Unknown OPTIONAL fields introduced in later MINOR
+releases are validated against the same schema path; validators MAY ignore semantic content they do not
+understand but MUST NOT reject the payload solely on that basis.
+
+The canonical schema URL is served by GitHub Pages and resolves at:
+`https://rdkcentral.github.io/oci-package-spec/schema/v1/package.schema.json`
+
+### Releases
+
+Releases are tagged on `main` as annotated tags of the form `vMAJOR.MINOR.PATCH` (pre-releases use
+`v1.1.0-rc.1`). Each release publishes:
+- a GitHub Release with notes extracted from `CHANGELOG.md`;
+- the schema file as a release asset (`package.schema-vMAJOR.MINOR.PATCH.json`);
+- a tarball of the spec documents (`ralf-spec-MAJOR.MINOR.PATCH.tar.gz`);
+- the schema served on GitHub Pages at the canonical URL above.
+
+See [RELEASING.md](RELEASING.md) for the maintainer runbook.
+
 ## Description
 
 ### Overview

--- a/format.md
+++ b/format.md
@@ -1,4 +1,5 @@
 # Package Format Specification
+**Version: 1.0.0**
 
 ## Description
 

--- a/metadata.md
+++ b/metadata.md
@@ -7,6 +7,7 @@ This specification describes the metadata that is stored in a package file.
 ```json
 {
   "id": "com.sky.myapp",
+  "specVersion": "1.0.0",
   "version": "1.2.3",
   "versionName": "1.2.3-beta",
   "name": "My Application",
@@ -103,6 +104,7 @@ This specification describes the metadata that is stored in a package file.
 | Metadata                              | Base     | Runtime  | Application/Service |
 | ------------------------------------- | -------- | -------- | ------------------- |
 | [id](#id)                             | Required | Required | Required            |
+| [specVersion](#specVersion)           | Required | Required | Required            |
 | [version](#version)                   | Required | Required | Required            |
 | [versionName](#versionName)           | Optional | Optional | Optional            |
 | [name](#name)                         | Optional | Optional | Optional            |
@@ -143,6 +145,19 @@ _Examples_
 ```json
 {
   "id": "rdk.browser.wpe"
+}
+```
+
+## specVersion
+
+The `specVersion` field identifies the version of the RALF specification that this package metadata adheres to.
+It must follow semantic versioning (X.Y.Z).
+
+_Examples_
+
+```json
+{
+  "specVersion": "1.0.0"
 }
 ```
 

--- a/metadata.md
+++ b/metadata.md
@@ -1,4 +1,5 @@
 # Package Metadata Specification
+**Version: 1.0.0**
 
 This specification describes the metadata that is stored in a package file.
 
@@ -150,14 +151,25 @@ _Examples_
 
 ## specVersion
 
-The `specVersion` field identifies the version of the RALF specification that this package metadata adheres to.
-It must follow semantic versioning (X.Y.Z).
+The `specVersion` field identifies the version of the RALF specification that this package metadata
+adheres to. It MUST follow Semantic Versioning in the form `MAJOR.MINOR.PATCH`, optionally followed by a
+pre-release tag (e.g. `1.1.0-rc.1`).
+
+Validators MUST select the schema directory matching the declared MAJOR (e.g. `specVersion: "1.2.0"`
+validates against `schema/v1/package.schema.json`). A validator implementing MAJOR `N` MUST accept any
+payload whose `specVersion` has MAJOR `N`, regardless of its MINOR/PATCH.
 
 _Examples_
 
 ```json
 {
   "specVersion": "1.0.0"
+}
+```
+
+```json
+{
+  "specVersion": "1.1.0-rc.1"
 }
 ```
 

--- a/schema/package.schema.json
+++ b/schema/package.schema.json
@@ -10,6 +10,11 @@
       "type": "string",
       "pattern": "^(?!.*\\.\\.)[a-zA-Z0-9](?:[a-zA-Z0-9._-]*[a-zA-Z0-9])?$"
     },
+    "specVersion": {
+      "description": "The version of the RALF specification this package adheres to.",
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
     "version": {
       "description": "The semantic version number of the package, this is strictly checked to ensure it contains numbers separated by periods",
       "type": "string",
@@ -68,6 +73,6 @@
       "additionalProperties": true
     }
   },
-  "required": ["id", "version", "packageType", "entryPoint"],
+  "required": ["id", "specVersion", "version", "packageType", "entryPoint"],
   "additionalProperties": false
 }

--- a/schema/v1/package.schema.json
+++ b/schema/v1/package.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema#",
-  "$id": "https://github.com/rdkcentral/oci-package-spec/blob/main/schema/package.schema.json",
+  "$id": "https://rdkcentral.github.io/oci-package-spec/schema/v1/package.schema.json",
   "title": "Package Metadata Schema",
   "description": "Schema defines a JSON structure that accurately represents the package metadata for use with OCI Packaging Format.",
   "type": "object",
@@ -11,9 +11,9 @@
       "pattern": "^(?!.*\\.\\.)[a-zA-Z0-9](?:[a-zA-Z0-9._-]*[a-zA-Z0-9])?$"
     },
     "specVersion": {
-      "description": "The version of the RALF specification this package adheres to.",
+      "description": "The version of the RALF specification this package adheres to. Semantic Versioning (MAJOR.MINOR.PATCH) with optional pre-release tag.",
       "type": "string",
-      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9A-Za-z.-]+)?$"
     },
     "version": {
       "description": "The semantic version number of the package, this is strictly checked to ensure it contains numbers separated by periods",


### PR DESCRIPTION
Adds a versioning policy so we can start cutting proper releases.

- New required `specVersion` field. SemVer with optional `-rc.N`. Validators pick schema by MAJOR.
- Policy in `format.md` covering MAJOR/MINOR/PATCH and schema compat.
- Schema moved to `schema/v1/`, `$id` points at the Pages URL.
- Version headers on the top-level docs, baselined at 1.0.0.
- `CHANGELOG.md` with the 1.0.0 entry.
- Release workflow on `v*.*.*` tags: checks headers and CHANGELOG match the tag, runs ajv, publishes the Release and Pages schema.
- PR validate workflow runs ajv against the schema.
- `RELEASING.md` for the next person cutting a release.
