### PR TITLE
release: 1.0.2 - bump version headers and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the RALF Specification will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2026-05-11
+
+### Fixed
+- Release workflow no longer pinned to the `github-pages` deployment
+  environment; tag-triggered Pages deploys are no longer blocked by
+  environment protection rules. (1.0.1 tag was published but its
+  workflow failed before producing any artifacts.)
+
 ## [1.0.0] - 2026-05-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # RALF (RDK Application Layer Format) Specification
-**Version: 1.0.0**
+**Version: 1.0.2**
 
 This repository contains the **RALF (RDK Application Layer Format) Specification**, which defines a standard for packaging applications, runtimes, and other resources as OCI (Open Container Initiative) artifacts for RDK devices.
 

--- a/format.md
+++ b/format.md
@@ -1,5 +1,5 @@
 # Package Format Specification
-**Version: 1.0.0**
+**Version: 1.0.2**
 
 ## Versioning
 

--- a/metadata.md
+++ b/metadata.md
@@ -1,5 +1,5 @@
 # Package Metadata Specification
-**Version: 1.0.0**
+**Version: 1.0.2**
 
 This specification describes the metadata that is stored in a package file.
 


### PR DESCRIPTION
1.0.1 tag was pushed without the doc version bumps so the release workflow's version-consistency check rejected it. Tag is protected and cannot be deleted, so cut 1.0.2 instead.