### PR TITLE
release: 1.0.3 — drop github-pages, switch canonical schema URL to raw

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,6 @@ on:
 
 permissions:
   contents: write
-  pages: write
-  id-token: write
-
-concurrency:
-  group: pages
-  cancel-in-progress: false
 
 jobs:
   release:
@@ -73,18 +67,3 @@ jobs:
           files: |
             dist/package.schema-*.json
             dist/ralf-spec-*.tar.gz
-
-      - name: Stage GitHub Pages site
-        run: |
-          mkdir -p site/schema
-          cp -r schema/v1 site/schema/v1
-          cp -r schema/v1 site/schema/latest
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: site
-
-      - name: Deploy to GitHub Pages
-        id: pages
-        uses: actions/deploy-pages@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the RALF Specification will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2026-05-11
+
+### Changed
+- Schema canonical URL now tracks `main` on raw.githubusercontent.com
+  instead of GitHub Pages. The schema `$id`, README, format.md, and
+  RELEASING.md were updated accordingly. The GitHub Release asset
+  (`package.schema-vX.Y.Z.json`) remains the version-pinned source.
+
+### Removed
+- GitHub Pages deploy steps from the release workflow. `deploy-pages@v4`
+  requires an `environment:` block, but the `github-pages` environment's
+  protection rules in this repository block tag-triggered deploys. Per-
+  version schema availability is preserved via Release assets.
+
 ## [1.0.2] - 2026-05-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # RALF (RDK Application Layer Format) Specification
-**Version: 1.0.2**
+**Version: 1.0.3**
 
 This repository contains the **RALF (RDK Application Layer Format) Specification**, which defines a standard for packaging applications, runtimes, and other resources as OCI (Open Container Initiative) artifacts for RDK devices.
 
@@ -11,7 +11,7 @@ RALF packages are distributed as single files with the `.ralf` extension (ZIP or
 
 *   **[Package Metadata Specification (metadata.md)](metadata.md):** This document defines the metadata that can be included in a package's config layer. This metadata provides essential information such as package name, version, dependencies, permissions, and resource requirements.
 
-*   **[Package Metadata JSON Schema (schema/v1/package.schema.json)](schema/v1/package.schema.json):** JSON Schema for validating the package metadata. Schemas are MAJOR-versioned; the canonical URL for the v1 schema is `https://rdkcentral.github.io/oci-package-spec/schema/v1/package.schema.json`.
+*   **[Package Metadata JSON Schema (schema/v1/package.schema.json)](schema/v1/package.schema.json):** JSON Schema for validating the package metadata. Schemas are MAJOR-versioned; the canonical URL for the v1 schema is `https://raw.githubusercontent.com/rdkcentral/oci-package-spec/main/schema/v1/package.schema.json`. Each tagged release also attaches `package.schema-vX.Y.Z.json` as a GitHub Release asset.
 
 *   **[Changelog (CHANGELOG.md)](CHANGELOG.md):** Notable changes per release.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -36,13 +36,12 @@ constitutes MAJOR/MINOR/PATCH changes.
    - verify that `CHANGELOG.md` and the doc version headers agree with the tag (`vX.Y.Z` → `X.Y.Z`);
    - compile the schema with `ajv`;
    - extract the matching CHANGELOG section as release notes;
-   - publish a GitHub Release with `package.schema-vX.Y.Z.json` and `ralf-spec-X.Y.Z.tar.gz` attached;
-   - deploy the schema to GitHub Pages.
+   - publish a GitHub Release with `package.schema-vX.Y.Z.json` and `ralf-spec-X.Y.Z.tar.gz` attached.
 
 6. **Verify the release.**
    - Confirm the GitHub Release page lists both artifacts and that pre-release tags are marked as such.
-   - Confirm the canonical schema URL responds with the new content:
-     `https://rdkcentral.github.io/oci-package-spec/schema/v1/package.schema.json`
+   - Confirm the canonical (main-tracking) schema URL serves the new content:
+     `https://raw.githubusercontent.com/rdkcentral/oci-package-spec/main/schema/v1/package.schema.json`
    - Optionally validate a sample package against the published schema:
      ```bash
      npx ajv-cli@5 validate -s schema/v1/package.schema.json -d sample.json --spec=draft2020
@@ -54,8 +53,6 @@ constitutes MAJOR/MINOR/PATCH changes.
   CHANGELOG on `main` in a follow-up PR, delete the bad tag, then retag.
 - **"version header mismatch"** — one of the doc files still shows the previous version. Same fix
   as above.
-- **Pages deploy fails on first run** — GitHub Pages must be enabled for the repository with the
-  source set to "GitHub Actions" in Settings → Pages.
 
 ## Tag and branch protection (one-time setup)
 

--- a/format.md
+++ b/format.md
@@ -1,5 +1,5 @@
 # Package Format Specification
-**Version: 1.0.2**
+**Version: 1.0.3**
 
 ## Versioning
 
@@ -22,8 +22,11 @@ MAJOR `N`, regardless of its MINOR/PATCH value. Unknown OPTIONAL fields introduc
 releases are validated against the same schema path; validators MAY ignore semantic content they do not
 understand but MUST NOT reject the payload solely on that basis.
 
-The canonical schema URL is served by GitHub Pages and resolves at:
-`https://rdkcentral.github.io/oci-package-spec/schema/v1/package.schema.json`
+The canonical schema URL tracks `main` on GitHub and resolves at:
+`https://raw.githubusercontent.com/rdkcentral/oci-package-spec/main/schema/v1/package.schema.json`
+
+For a pinned, immutable copy of the schema as it shipped with a specific spec version, use the
+release asset URL (see below).
 
 ### Releases
 
@@ -31,8 +34,7 @@ Releases are tagged on `main` as annotated tags of the form `vMAJOR.MINOR.PATCH`
 `v1.1.0-rc.1`). Each release publishes:
 - a GitHub Release with notes extracted from `CHANGELOG.md`;
 - the schema file as a release asset (`package.schema-vMAJOR.MINOR.PATCH.json`);
-- a tarball of the spec documents (`ralf-spec-MAJOR.MINOR.PATCH.tar.gz`);
-- the schema served on GitHub Pages at the canonical URL above.
+- a tarball of the spec documents (`ralf-spec-MAJOR.MINOR.PATCH.tar.gz`).
 
 See [RELEASING.md](RELEASING.md) for the maintainer runbook.
 

--- a/metadata.md
+++ b/metadata.md
@@ -1,5 +1,5 @@
 # Package Metadata Specification
-**Version: 1.0.2**
+**Version: 1.0.3**
 
 This specification describes the metadata that is stored in a package file.
 

--- a/schema/v1/package.schema.json
+++ b/schema/v1/package.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema#",
-  "$id": "https://rdkcentral.github.io/oci-package-spec/schema/v1/package.schema.json",
+  "$id": "https://raw.githubusercontent.com/rdkcentral/oci-package-spec/main/schema/v1/package.schema.json",
   "title": "Package Metadata Schema",
   "description": "Schema defines a JSON structure that accurately represents the package metadata for use with OCI Packaging Format.",
   "type": "object",


### PR DESCRIPTION
The 1.0.2 release attached the GitHub Release asset successfully but `actions/deploy-pages@v4` rejected the deploy: it requires the `github-pages` environment, whose protection rules in this repo block tag-triggered deploys.

Rather than chase env config, drop Pages from the release flow.

- Remove Pages-related steps, permissions, and concurrency from `release.yml`.
- Switch the canonical schema URL (schema `$id`, README, format.md, RELEASING.md) to:
    `https://raw.githubusercontent.com/rdkcentral/oci-package-spec/main/schema/v1/package.schema.json`
- Version-pinned copies stay available as `package.schema-vX.Y.Z.json` Release assets.
- Doc version headers + CHANGELOG bumped to 1.0.3.